### PR TITLE
Update union-value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "stable"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.10"
+  - "12"
+  - "10"
+  - "8"
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: "0.10"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "is-extendable": "^0.1.1",
     "sort-asc": "^0.2.0",
     "sort-desc": "^0.2.0",
-    "union-value": "^0.2.3"
+    "union-value": "^2.0.1"
   },
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=8.0.0"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
Currently specified version of union-value has a dependency with a vulnerability. (https://snyk.io/vuln/SNYK-JS-SETVALUE-450213)
From the commits on union-value (https://github.com/jonschlinkert/union-value/compare/0.2.3...2.0.1), it's breaking change for Node.js version 4 or lower.